### PR TITLE
Added dylib as an extension for homebrew lua

### DIFF
--- a/luastatic.lua
+++ b/luastatic.lua
@@ -30,7 +30,7 @@ end
 -- parse arguments
 for i, name in ipairs(arg) do
   local extension = name:match("%.(%a+)$")
-  if extension == "lua" or extension == "a" then
+  if extension == "lua" or extension == "a" or extension =="dylib" then
     if not fileExists(name) then
       print("file does not exist: ", name)
       os.exit(1)
@@ -45,7 +45,7 @@ for i, name in ipairs(arg) do
 
     if extension == "lua" then
       table.insert(lua_source_files, info)
-    elseif extension == "a" then
+    elseif extension == "a" or extension == "dylib" then
       -- the library is one of three types: liblua.a, a Lua module, 
       -- or a library dependency
       local nmout = shellout("nm " .. name)


### PR DESCRIPTION
homebrew doesn't name or symlink dylib to *.a in install path of lua.  By adding this code was able to compile using this command on OS X.  

`luastatic test.lua /usr/local/Cellar/lua/5.2.4_3/lib/liblua.5.2.4.dylib -I/usr/local/include`