### PR TITLE
Fix entry point loading if the file is not in current dir

### DIFF
--- a/luastatic.lua
+++ b/luastatic.lua
@@ -287,7 +287,7 @@ if chunk then
 else
   error(errstr)
 end
-]]):format(mainlua.basename_noextension, mainlua.basename_noextension))
+]]):format(mainlua.dotpath_noextension, mainlua.basename_noextension))
 
 out([[
 


### PR DESCRIPTION
`dotpath_noextension` is used as key in the bundle table when
putting modules there, use it to retrieve main module as well.
`basename_noextension` may be different from it if the main
module file is inside a directory.