### PR TITLE
Return a diagnostic message when couldn't find bundled module

### DIFF
--- a/luastatic.lua
+++ b/luastatic.lua
@@ -274,6 +274,8 @@ local function lua_loader(name)
         ("error loading module '%s' from luastatic bundle:\n\t %s"):format(name, errstr)
       )
     end
+  else
+    return ("\n\tno module '%s' in luastatic bundle"):format(name)
   end
 end
 table.insert(package.loaders or package.searchers, 2, lua_loader)

--- a/luastatic.lua
+++ b/luastatic.lua
@@ -271,7 +271,8 @@ local function lua_loader(name)
       return chunk
     else
       error(
-        ("error loading module '%s' from luastatic bundle:\n\t %s"):format(name, errstr)
+        ("error loading module '%s' from luastatic bundle:\n\t%s"):format(name, errstr),
+        0
       )
     end
   else
@@ -287,7 +288,7 @@ local chunk, errstr = load_string(lua_bundle["%s"], "%s")
 if chunk then
   chunk()
 else
-  error(errstr)
+  error(errstr, 0)
 end
 ]]):format(mainlua.basename_noextension, mainlua.basename_noextension))
 


### PR DESCRIPTION
Looks like this (the third line):

```
[string "test"]:4: module 'missing' not found:
	no field package.preload['missing']
	no module 'missing' in luastatic bundle
	no file '/home/mpeterv/luastatic/lua53/share/lua/5.3/missing.lua'
	no file '/home/mpeterv/luastatic/lua53/share/lua/5.3/missing/init.lua'
	no file './missing.lua'
	no file '/home/mpeterv/luastatic/lua53/lib/lua/5.3/missing.so'
	no file '/home/mpeterv/luastatic/lua53/lib/lua/5.3/loadall.so'
	no file './missing.so'
```

Also removed position inside internal luastatic code from syntax error messages.
