### PR TITLE
Fix typo "lau" -> "lua" in include in C template

### DIFF
--- a/luastatic.lua
+++ b/luastatic.lua
@@ -224,7 +224,7 @@ out([[
 #ifdef __cplusplus
 extern "C" {
 #endif
-#include <lauxlib.h>
+#include <luaxlib.h>
 #include <lua.h>
 #include <lualib.h>
 #ifdef __cplusplus


### PR DESCRIPTION
It's Lua, not Lau ;)

I spent like 10 minutes looking at the error message before I could figure out what was wrong.