### PR TITLE
Fix Formatting Error

### DIFF
--- a/luastatic.lua
+++ b/luastatic.lua
@@ -371,7 +371,7 @@ out(([[
 		!= LUA_OK
 	)
 	{
-		fprintf(stderr, "luaL_loadbuffer: %%s\n", lua_tostring(L, -1));
+		fprintf(stderr, "luaL_loadbuffer: %%%%s\n", lua_tostring(L, -1));
 		lua_close(L);
 		return 1;
 	}


### PR DESCRIPTION
I noticed this when using clang, which warned about unused strformat arguments. The `%%s` will produce `s` in the final C code, instead of the `%s` intended. `%%%s` fixes that (both `%` are escaped now).