### PR TITLE
add table created by lua_bundle to namespace

### DIFF
--- a/luastatic.lua
+++ b/luastatic.lua
@@ -378,6 +378,9 @@ out(([[
 	
 	/* lua_bundle */
 	lua_newtable(L);
+    lua_settop(L, lua_gettop(L)+1);
+    lua_copy(L, -2, -1);
+    lua_setglobal(L, "@@@");
 ]]):format(mainlua.basename_noextension));
 
 for i, file in ipairs(lua_source_files) do


### PR DESCRIPTION
The name is `@@@.` Therefore, the table doesn't pollute the namespace
unless the programmer deliberately uses` _ENV["@@@"]` for his own
values.

This facility is helpful for interoperability with [luaproc](https://github.com/askyrme/luaproc):
Every thread can decide to receive some or all values values from this table
and load them to access
functionality otherwise only available to the main thread.

Questions:

* Can this be implemented in a better or more generic way?
* Specifically, should one add a switch to enable or disable this feature?
* Or to choose the variable name?