### PR TITLE
In case of compiling with C++ compiler luaopen_### C functions must b…

### DIFF
--- a/luastatic.lua
+++ b/luastatic.lua
@@ -302,6 +302,21 @@ static int docall (lua_State *L, int narg, int nres) {
 	return status;
 }
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+]])
+
+for _, library in ipairs(module_library_files) do
+	out(('	int luaopen_%s(lua_State *L);\n'):format(library.dotpath_underscore))
+end
+
+out([[
+#ifdef __cplusplus
+}
+#endif
+
+
 int main(int argc, char *argv[])
 {
 	lua_State *L = luaL_newstate();
@@ -391,7 +406,6 @@ for i, file in ipairs(lua_source_files) do
 end
 
 for _, library in ipairs(module_library_files) do
-	out(('	int luaopen_%s(lua_State *L);\n'):format(library.dotpath_underscore))
 	out(('	lua_pushcfunction(L, luaopen_%s);\n'):format(library.dotpath_underscore))
 	out(('	lua_setfield(L, -2, "%s");\n\n'):format(library.dotpath_noextension))
 end


### PR DESCRIPTION
Hi!

I was trying to build executable with luamoonfltk lib which is must be compiled with C++ compiler. So I examined the source code and notice that there are several extern "C" blocks within #ifdef __cplusplus.

However I was not able to build the executable with luastatic installed via luarocks. There were several errors:
```
/tmp/ccdm6fm6.o:main.luastatic.c:(.text.startup+0x13c): undefined reference to `luaopen_moonfltk(lua_State*)'
/tmp/ccdm6fm6.o:main.luastatic.c:(.text.startup+0x16c): undefined reference to `luaopen_moonfltk_background(lua_State*)'
```

In case of using C++ in CC (which is required to compile with libmoonfltk.a, which is using a bunch of exception related symbols) declarations of luaopen_moonfltk(lua_State*) out of extern "C" blocks means declaration of a C++ symbol with mangled name (function overload implemented in terms of name mangling encoding argument with each function overload in a resulting symbol).

So I thought we need to declare all luaopen_### function in extern "C" block in case of C++. I thought it would be ok to declare all of them just before main.

Hope you will be able to understand my Runglish, feel free to ask any questions.